### PR TITLE
Update mapping.json

### DIFF
--- a/mapping.json
+++ b/mapping.json
@@ -74,7 +74,7 @@
 		},
 		{
 			"name": "Oracle / AMM",
-			"id": "Oracle_AMM"
+			"id": "oracle_amm"
 		},
 		{
 			"name": "Cross Chain",


### PR DESCRIPTION
lowercase oracle_amm is used as id while its defined as "Oracle_AMM". Due to which filtering is not being done properly on the OSWAR website.